### PR TITLE
Inject local marker value as environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ These variables are described below,
 -   RJPP_SCM_URL: URl of the repository as String which is defined in Remote Jenkinsfile Provider. 
     Comma separated if there are more than one URL definition.
 -   RJPP_JENKINSFILE: Script Path of the Jenkinsfile as defined in Remote Jenkinsfile Provider.
--   RJPP_BRANCH: Branch name of the Jenkinsfile where it is cloned
+-   RJPP_BRANCH: Branch name of the Jenkinsfile where it is cloned.
+-   RJPP_LOCAL_MARKER: Path to the local marker file as defined in Remote Jenkinsfile Provider.
 
 These variables can be retrieved same as other environment variables in Jenkins.
 ```groovy
 echo "${env.RJPP_SCM_URL}"
 echo "${env.RJPP_JENKINSFILE}"
 echo "${env.RJPP_BRANCH}"
+echo "${env.RJPP_LOCAL_MARKER}"
 ```
 
 **This feature only works for Git SCM definitions**

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/RemoteJenkinsFileItemListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/RemoteJenkinsFileItemListener.java
@@ -42,6 +42,7 @@ public class RemoteJenkinsFileItemListener extends EnvironmentContributor {
                     String jenkinsFile = extendedSCMBinder.getRemoteJenkinsFile();
                     envs.put(RemoteJenkinsFileItemListener.RJPP_SCM_ENV_NAME, scmUrls.toString());
                     envs.put(RemoteJenkinsFileItemListener.RJPP_JFILE_ENV_NAME, jenkinsFile);
+                    envs.put(RemoteJenkinsFileItemListener.RJPP_JFILE_ENV_NAME, "local_marker_from_provider");
                     if( extendedSCMBinder.isMatchBranches())
                         envs.put(RemoteJenkinsFileItemListener.RJPP_BRANCH_ENV_NAME, extendedSCMBinder.getRemoteJenkinsFileBranch());
                     else

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/RemoteJenkinsFileItemListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/RemoteJenkinsFileItemListener.java
@@ -21,6 +21,7 @@ public class RemoteJenkinsFileItemListener extends EnvironmentContributor {
     public static final String RJPP_SCM_ENV_NAME = "RJPP_SCM_URL";
     public static final String RJPP_JFILE_ENV_NAME = "RJPP_JENKINSFILE";
     public static final String RJPP_BRANCH_ENV_NAME = "RJPP_BRANCH";
+    public static final String RJPP_LOCMARKER_ENV_NAME = "RJPP_LOCAL_MARKER";
 
     @Override
     public void buildEnvironmentFor(@NonNull Run r, @NonNull EnvVars envs, @NonNull TaskListener listener) throws IOException, InterruptedException {


### PR DESCRIPTION
This pull request injects the "local marker" option used in the provider into the Jenkins environment so that it can be referenced in the pipeline.
Currently, I am still working on extracting the value stored in "local marker", but I have the template code setup, and the value for the local marker is a [placeholder](https://github.com/jenkinsci/remote-file-plugin/blob/14d6f1ded3fe47def3b9ae0ac6bb7cf382c8fe83/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/RemoteJenkinsFileItemListener.java#L45).
I have not opened an issue for this but let me know if that would be helpful. The context for this is that we are trying to have multiple local markers in a single repository, and this local marker file also contains values that will be used in the build process. The issue is that once the pipeline starts its run, it won't know which local marker was used to start the pipeline because this parameter isn't injected into it.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
