### PR TITLE
[JENKINS-57023] Remove deprecated 'workflow-cps-global-lib' 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,8 @@ THE SOFTWARE.
             <artifactId>mailer</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps-global-lib</artifactId>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>pipeline-groovy-lib</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Replaces the [deprecated `workflow-cps-global-lib`](https://plugins.jenkins.io/workflow-cps-global-lib/) with `pipeline-groovy-lib` ([JENKINS-57023](https://issues.jenkins.io/browse/JENKINS-57023)).

It's not possible to uninstall the deprecated plugin, since it's still required by this one.

closes #90

--------------------------------

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
