### PR TITLE
Remove deprecated `java.level` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@ THE SOFTWARE.
         <tag>HEAD</tag>
     </scm>
     <properties>
-        <java.level>8</java.level>
         <java.version>1.8</java.version>
         <jenkins.version>2.303.3</jenkins.version>
         <cloudbees-bitbucket-branch-source.version>773.v4b_9b_005b_562b_</cloudbees-bitbucket-branch-source.version>


### PR DESCRIPTION
The `java.level` property was deprecated in [plugin parent POM 4.40](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.40) and should be removed from this plugin's POM. In the future this warning will be changed to an error and will break the build. See https://github.com/jenkinsci/plugin-pom/pull/522 for details.