### PR TITLE
Modernize to latest versions supported by Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.40</version>
+        <version>4.51</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -59,18 +59,17 @@ THE SOFTWARE.
     </scm>
     <properties>
         <java.version>1.8</java.version>
-        <jenkins.version>2.303.3</jenkins.version>
+        <jenkins.version>2.346.3</jenkins.version>
         <cloudbees-bitbucket-branch-source.version>773.v4b_9b_005b_562b_</cloudbees-bitbucket-branch-source.version>
         <workflow-aggregator.version>581.v0c46fa_697ffd</workflow-aggregator.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
     </properties>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.303.x</artifactId>
-                <version>1409.v7659b_c072f18</version>
+                <artifactId>bom-2.346.x</artifactId>
+                <version>1763.v092b_8980a_f5e</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Hi!

This PR aims to modernize tooling and move this plugin closer to the [recommended Jenkins baseline version](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) without making the change too big. If this goes well, I can follow up with a subsequent PR to modernize further.

Fixes #109 
Progress toward #126 
Progress toward #134 

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePluginForJava8