### PR TITLE
Require Jenkins 2.504.3 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,6 @@ buildPlugin(
   forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
-    [platform: 'linux', jdk: 17],
-    [platform: 'windows', jdk: 17],
+    [platform: 'linux', jdk: 25],
+    [platform: 'windows', jdk: 21],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@ THE SOFTWARE.
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>http://opensource.org/licenses/MIT</url>
+            <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
     <developers>
@@ -55,25 +55,21 @@ THE SOFTWARE.
         <connection>scm:git:git@github.com:jenkinsci/remote-file-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/remote-file-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/remote-file-plugin</url>
-        <tag>remote-file-1.24</tag>
+        <tag>${scmTag}</tag>
     </scm>
     <properties>
-        <jenkins.baseline>2.361</jenkins.baseline>
-        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+        <jenkins.baseline>2.504</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.3</jenkins.version>
         <revision>999999</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>${jenkins.baseline}}.4</jenkins.version>
-        <cloudbees-bitbucket-branch-source.version>937.2.1</cloudbees-bitbucket-branch-source.version>
-        <java.version>11</java.version>
         <workflow-aggregator.version>596.v8c21c963d92d</workflow-aggregator.version>
-        <commons-lang3.version>3.19.0</commons-lang3.version>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-${jenkins.baseline}}.x</artifactId>
-                <version>2102.v854b_fec19c92</version>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                <version>5601.v59f37270a_349</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -151,9 +147,8 @@ THE SOFTWARE.
             <artifactId>script-security</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -178,12 +173,6 @@ THE SOFTWARE.
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-bitbucket-branch-source</artifactId>
-            <version>${cloudbees-bitbucket-branch-source.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/RemoteJenkinsFileItemListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/RemoteJenkinsFileItemListener.java
@@ -27,14 +27,11 @@ public class RemoteJenkinsFileItemListener extends EnvironmentContributor {
 
     @Override
     public void buildEnvironmentFor(@NonNull Run r, @NonNull EnvVars envs, @NonNull TaskListener listener) throws IOException, InterruptedException {
-        if (r instanceof WorkflowRun) {
-            WorkflowRun workflowRun = (WorkflowRun) r;
+        if (r instanceof WorkflowRun workflowRun) {
             WorkflowJob workflowJob = workflowRun.getParent();
             FlowDefinition flowDefinition = workflowJob.getDefinition();
-            if (flowDefinition instanceof ExtendedSCMBinder) {
-                ExtendedSCMBinder extendedSCMBinder = (ExtendedSCMBinder) flowDefinition;
-                if (extendedSCMBinder.getRemoteJenkinsFileSCM() instanceof GitSCM) {
-                    GitSCM gitSCM = (GitSCM) extendedSCMBinder.getRemoteJenkinsFileSCM();
+            if (flowDefinition instanceof ExtendedSCMBinder extendedSCMBinder) {
+                if (extendedSCMBinder.getRemoteJenkinsFileSCM() instanceof GitSCM gitSCM) {
                     StringJoiner scmUrls = new StringJoiner(",");
                     for (RemoteConfig remoteConfig : gitSCM.getRepositories()) {
                         for (URIish urIish : remoteConfig.getURIs()) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/scm/ExcludeFromChangeSet.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/scm/ExcludeFromChangeSet.java
@@ -48,18 +48,15 @@ public class ExcludeFromChangeSet extends GitSCMExtension {
 
         @Override
         public void onCheckout(Run<?, ?> build, SCM scm, FilePath workspace, TaskListener listener, @CheckForNull File changelogFile, @CheckForNull SCMRevisionState pollingBaseline) throws Exception {
-            if (!(build instanceof WorkflowRun)) {
+            if (!(build instanceof WorkflowRun workflowRun)) {
                 return;
             }
-            WorkflowRun workflowRun = (WorkflowRun) build;
-            WorkflowJob workflowJob = ((WorkflowRun) build).getParent();
+            WorkflowJob workflowJob = workflowRun.getParent();
             FlowDefinition flowDefinition = workflowJob.getDefinition();
-            if (!(flowDefinition instanceof ExtendedSCMBinder)) {
+            if (!(flowDefinition instanceof ExtendedSCMBinder extendedSCMBinder)) {
                 return;
             }
-            ExtendedSCMBinder extendedSCMBinder = (ExtendedSCMBinder) flowDefinition;
-            if ( extendedSCMBinder.getRemoteJenkinsFileSCM() instanceof GitSCM) {
-                GitSCM remoteJenkinsFileSCM = (GitSCM) extendedSCMBinder.getRemoteJenkinsFileSCM();
+            if (extendedSCMBinder.getRemoteJenkinsFileSCM() instanceof GitSCM remoteJenkinsFileSCM) {
                 if (remoteJenkinsFileSCM.getKey().equals(scm.getKey())) {
                     DescribableList<GitSCMExtension, GitSCMExtensionDescriptor> extensions = remoteJenkinsFileSCM.getExtensions();
                     for (GitSCMExtension gitSCMExtension : extensions) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/scm/ExtendedSCMBinder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/scm/ExtendedSCMBinder.java
@@ -84,9 +84,8 @@ public class ExtendedSCMBinder extends FlowDefinition {
                 String newJenkinsFile = "Jenkinsfile";
                 //Search for ParametersAction in Actions
                 for (Action action : actions) {
-                    if (action instanceof ParametersAction) {
-                        //This can be the parameter that we are looking for
-                        ParametersAction parametersAction = (ParametersAction) action;
+                    //This can be the parameter that we are looking for
+                    if (action instanceof ParametersAction parametersAction) {
                         //Check if the parameter name matches with JenkinsfileParameter
                         ParameterValue parameterValue = parametersAction.getParameter(jenkinsfileParameterName);
                         if( parameterValue != null) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/scm/LocalMarkerSCMSourceCriteria.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/multibranch/extended/scm/LocalMarkerSCMSourceCriteria.java
@@ -24,20 +24,23 @@ public class LocalMarkerSCMSourceCriteria {
         }
 
         SCMProbeStat stat = probe.stat(localMarker);
-        switch (stat.getType()) {
-            case NONEXISTENT:
+        return switch (stat.getType()) {
+            case NONEXISTENT -> {
                 if (stat.getAlternativePath() != null) {
                     taskListener.getLogger().format("      ‘%s’ not found (but found ‘%s’, search is case sensitive)%n", localMarker, stat.getAlternativePath());
                 } else {
                     taskListener.getLogger().format("      ‘%s’ not found%n", localMarker);
                 }
-                return false;
-            case DIRECTORY:
+                yield false;
+            }
+            case DIRECTORY -> {
                 taskListener.getLogger().format("      ‘%s’ found directory%n", localMarker);
-                return true;
-            default:
+                yield true;
+            }
+            default -> {
                 taskListener.getLogger().format("      ‘%s’ found%n", localMarker);
-                return true;
-        }
+                yield true;
+            }
+        };
     }
 }


### PR DESCRIPTION
### Require Jenkins 2.504.3 or newer

Update to the [recommended baseline version](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/). The plugin BOM continues to receive updates for the 2.504.x line.

Switch testing to JDK 21 and 25. Java 17 byte code will continue to be delivered as the release.

### Testing done

None. Rely on `ci.jenkins.io`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed